### PR TITLE
Update unfixed CVE ranges

### DIFF
--- a/cves/CVE-2020-8554.yaml
+++ b/cves/CVE-2020-8554.yaml
@@ -9,4 +9,4 @@ cvss:
     scoreV3: 6.3
     vectorV3: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
 affected:
-  - range: "<= 1.20"
+  - range: ">= 0.0.0"

--- a/cves/CVE-2020-8562.yaml
+++ b/cves/CVE-2020-8562.yaml
@@ -6,7 +6,4 @@ cvss:
     scoreV3: 2.2
     vectorV3: CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:L/I:N/A:N
 affected:
-  - range: "<= 1.18.18"
-  - range: "<= 1.19.10"
-  - range: "<= 1.20.6"
-  - range: "<= 1.21.0"
+  - range: ">= 0.0.0"


### PR DESCRIPTION
There are still 2 CVEs that we track that are unfixed. Instead of having to keep updating the range upon new k8s version, I figured setting the range to `>= 0.0.0` makes life easier