### PR TITLE
Add published date to CVEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 This repository is meant to be a single source of truth for
 Kubernetes-related CVEs. The data gathered here is meant to be as up-to-date
-as possible. Currently, the data comes from a combination of NVD and Kubernetes GitHub issues.
+as possible. Currently, the data comes from a combination of:
+
+* NVD
+* Kubernetes GitHub issues
+* Announcements from [kubernetes-security-announce](https://groups.google.com/g/kubernetes-security-announce)
 
 Though this repository is meant to be a single source of truth,
 there may be mistakes. We try to keep everything as accurate and up-to-date
@@ -16,6 +20,7 @@ to make a pull request, and we will review it.
 cve: 'CVEID (ex: CVE-2019-16276)'
 url: Alternate URL for the vulnerability. This will typically be a link to NVD.
 issueUrl: URL to the relevant Issue/Pull Request in the Kubernetes GitHub repository
+published: 'Date CVE was first published publicly (ex: 2006-01-02)'
 description: CVE description
 components:
   # list of affected components

--- a/cves/CVE-2015-7528.yaml
+++ b/cves/CVE-2015-7528.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2015-7528
 url: https://nvd.nist.gov/vuln/detail/CVE-2015-7528
 issueUrl: https://github.com/kubernetes/kubernetes/pull/17886
+published: 2015-11-27
 description: Kubernetes before 1.2.0-alpha.5 allows remote attackers to read arbitrary pod logs via a container name.
 cvss:
   nvd:

--- a/cves/CVE-2016-1905.yaml
+++ b/cves/CVE-2016-1905.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2016-1905
 url: https://nvd.nist.gov/vuln/detail/CVE-2016-1905
 issueUrl: https://github.com/kubernetes/kubernetes/issues/19479
+published: 2016-01-11
 description: The API server in Kubernetes does not properly check admission control, which allows remote authenticated users to access additional resources via a crafted patched object.
 components:
   - kube-apiserver

--- a/cves/CVE-2016-7075.yaml
+++ b/cves/CVE-2016-7075.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2016-7075
 url: https://nvd.nist.gov/vuln/detail/CVE-2016-7075
 issueUrl: https://github.com/kubernetes/kubernetes/issues/34517
+published: 2016-10-10
 description: It was found that Kubernetes did not correctly validate X.509 client intermediate certificate host name fields. An attacker could use this flaw to bypass authentication requirements by using a specially crafted X.509 certificate.
 components:
   - kube-apiserver

--- a/cves/CVE-2017-1000056.yaml
+++ b/cves/CVE-2017-1000056.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2017-1000056
 url: https://nvd.nist.gov/vuln/detail/CVE-2017-1000056
 issueUrl: https://github.com/kubernetes/kubernetes/issues/43459
+published: 2017-03-21
 description: Kubernetes version 1.5.0-1.5.4 is vulnerable to a privilege escalation in the PodSecurityPolicy admission plugin resulting in the ability to make use of any existing PodSecurityPolicy object.
 cvss:
   nvd:

--- a/cves/CVE-2017-1002100.yaml
+++ b/cves/CVE-2017-1002100.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2017-1002100
 url: https://nvd.nist.gov/vuln/detail/CVE-2017-1002100
 issueUrl: https://github.com/kubernetes/kubernetes/issues/47611
+published: 2017-06-15
 description: Default access permissions for Persistent Volumes (PVs) created by the Kubernetes Azure cloud provider in versions 1.6.0 to 1.6.5 are set to "container" which exposes a URI that can be accessed without authentication on the public internet. Access to the URI string requires privileged access to the Kubernetes cluster or authenticated access to the Azure portal.
 cvss:
   nvd:

--- a/cves/CVE-2017-1002101.yaml
+++ b/cves/CVE-2017-1002101.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2017-1002101
 url: https://nvd.nist.gov/vuln/detail/CVE-2017-1002101
 issueUrl: https://github.com/kubernetes/kubernetes/issues/60813
+published: 2018-03-05
 description: In Kubernetes versions 1.3.x, 1.4.x, 1.5.x, 1.6.x and prior to versions 1.7.14, 1.8.9, 1.9.4, and 1.10.0-beta.3 containers using subpath volume mounts with any volume type (including non-privileged pods, subject to file permissions) can access files/directories outside of the volume, including the host's filesystem.
 components:
   - kubelet

--- a/cves/CVE-2017-1002102.yaml
+++ b/cves/CVE-2017-1002102.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2017-1002102
 url: https://nvd.nist.gov/vuln/detail/CVE-2017-1002102
 issueUrl: https://github.com/kubernetes/kubernetes/issues/60814
+published: 2018-03-05
 description: In Kubernetes versions 1.3.x, 1.4.x, 1.5.x, 1.6.x and prior to versions 1.7.14, 1.8.9, 1.9.4, and 1.10.0-beta.1 containers using a secret, configMap, projected or downwardAPI volume can trigger deletion of arbitrary files/directories from the nodes where they are running.
 components:
   - kubelet

--- a/cves/CVE-2017-14491.yaml
+++ b/cves/CVE-2017-14491.yaml
@@ -1,5 +1,6 @@
 cve: CVE-2017-14491
 url: https://nvd.nist.gov/vuln/detail/CVE-2017-14491
+published: 2017-10-02
 description: Heap-based buffer overflow in dnsmasq before 2.78 allows remote attackers to cause a denial of service (crash) or execute arbitrary code via a crafted DNS response.
 components:
   - kube-dns

--- a/cves/CVE-2018-1002100.yaml
+++ b/cves/CVE-2018-1002100.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2018-1002100
 url: https://nvd.nist.gov/vuln/detail/CVE-2018-1002100
 issueUrl: https://github.com/kubernetes/kubernetes/issues/61297
+published: 2018-03-16
 description: In Kubernetes versions 1.5.x, 1.6.x, 1.7.x, 1.8.x, and prior to version 1.9.6, the kubectl cp command insecurely handles tar data returned from the container, and can be caused to overwrite arbitrary local files.
 components:
   - kubectl

--- a/cves/CVE-2018-1002101.yaml
+++ b/cves/CVE-2018-1002101.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2018-1002101
 url: https://nvd.nist.gov/vuln/detail/CVE-2018-1002101
 issueUrl: https://github.com/kubernetes/kubernetes/issues/65750
+published: 2018-07-03
 description: In Kubernetes versions 1.9.0-1.9.9, 1.10.0-1.10.5, and 1.11.0-1.11.1, user input was handled insecurely while setting up volume mounts on Windows nodes, which could lead to command line argument injection.
 cvss:
   nvd:

--- a/cves/CVE-2018-1002102.yaml
+++ b/cves/CVE-2018-1002102.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2018-1002102
 url: https://nvd.nist.gov/vuln/detail/CVE-2018-1002102
 issueUrl: https://github.com/kubernetes/kubernetes/issues/85867
+published: 2019-12-03
 description: Improper validation of URL redirection in the Kubernetes API server in versions prior to v1.14.0 allows an attacker-controlled Kubelet to redirect API server requests from streaming endpoints to arbitrary hosts. Impacted API servers will follow the redirect as a GET request with client-certificate credentials for authenticating to the Kubelet.
 components:
   - kube-apiserver

--- a/cves/CVE-2018-1002105.yaml
+++ b/cves/CVE-2018-1002105.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2018-1002105
 url: https://nvd.nist.gov/vuln/detail/CVE-2018-1002105
 issueUrl: https://github.com/kubernetes/kubernetes/issues/71411
+published: 2018-11-26
 description: In all Kubernetes versions prior to v1.10.11, v1.11.5, and v1.12.3, incorrect handling of error responses to proxied upgrade requests in the kube-apiserver allowed specially crafted requests to establish a connection through the Kubernetes API server to backend servers, then send arbitrary requests over the same connection directly to the backend, authenticated with the Kubernetes API server's TLS credentials used to establish the backend connection.
 components:
   - kube-apiserver

--- a/cves/CVE-2019-1002100.yaml
+++ b/cves/CVE-2019-1002100.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2019-1002100
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-1002100
 issueUrl: https://github.com/kubernetes/kubernetes/issues/74534
+published: 2019-02-25
 description: |
   In all Kubernetes versions prior to v1.11.8, v1.12.6, and v1.13.4, users that are authorized to make patch requests to the Kubernetes API Server can send a specially crafted patch of type "json-patch" (e.g. `kubectl patch --type json` or `"Content-Type: application/json-patch+json"`) that consumes excessive resources while processing, causing a Denial of Service on the API Server.
 components:

--- a/cves/CVE-2019-1002101.yaml
+++ b/cves/CVE-2019-1002101.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2019-1002101
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-1002101
 issueUrl: https://github.com/kubernetes/kubernetes/pull/75037
+published: 2019-03-06
 description: The kubectl cp command allows copying files between containers and the user machine. To copy files from a container, Kubernetes creates a tar inside the container, copies it over the network, and kubectl unpacks it on the user’s machine. If the tar binary in the container is malicious, it could run any code and output unexpected, malicious results. An attacker could use this to write files to any path on the user’s machine when kubectl cp is called, limited only by the system permissions of the local user. The untar function can both create and follow symbolic links. The issue is resolved in kubectl v1.11.9, v1.12.7, v1.13.5, and v1.14.0.
 components:
   - kubectl

--- a/cves/CVE-2019-11243.yaml
+++ b/cves/CVE-2019-11243.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2019-11243
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-11243
 issueUrl: https://github.com/kubernetes/kubernetes/issues/76797
+published: 2019-04-18
 description: In Kubernetes v1.12.0-v1.12.4 and v1.13.0, the rest.AnonymousClientConfig() method returns a copy of the provided config, with credentials removed (bearer token, username/password, and client certificate/key data). In the affected versions, rest.AnonymousClientConfig() did not effectively clear service account credentials loaded using rest.InClusterConfig()
 components:
   - client-go

--- a/cves/CVE-2019-11244.yaml
+++ b/cves/CVE-2019-11244.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2019-11244
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-11244
 issueUrl: https://github.com/kubernetes/kubernetes/issues/76676
+published: 2019-04-16
 description: In Kubernetes v1.8.x-v1.14.x, schema info is cached by kubectl in the location specified by --cache-dir (defaulting to $HOME/.kube/http-cache), written with world-writeable permissions (rw-rw-rw-). If --cache-dir is specified and pointed at a different location accessible to other users/groups, the written files may be modified by other users/groups and disrupt the kubectl invocation.
 components:
   - kubectl

--- a/cves/CVE-2019-11245.yaml
+++ b/cves/CVE-2019-11245.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2019-11245
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-11245
 issueUrl: https://github.com/kubernetes/kubernetes/issues/78308
+published: 2019-05-24
 description: |
   In kubelet v1.13.6 and v1.14.2, containers for pods that do not specify an explicit runAsUser attempt to run as uid 0 (root) on container restart, or if the image was previously pulled to the node. If the pod specified mustRunAsNonRoot: true, the kubelet will refuse to start the container as root. If the pod did not specify mustRunAsNonRoot: true, the kubelet will run the container as uid 0.
 components:

--- a/cves/CVE-2019-11246.yaml
+++ b/cves/CVE-2019-11246.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2019-11246
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-11246
 issueUrl: https://github.com/kubernetes/kubernetes/pull/76788
+published: 2019-04-30
 description: The kubectl cp command allows copying files between containers and the user machine. To copy files from a container, Kubernetes runs tar inside the container to create a tar archive, copies it over the network, and kubectl unpacks it on the user’s machine. If the tar binary in the container is malicious, it could run any code and output unexpected, malicious results. An attacker could use this to write files to any path on the user’s machine when kubectl cp is called, limited only by the system permissions of the local user. Kubernetes affected versions include versions prior to 1.12.9, versions prior to 1.13.6, versions prior to 1.14.2, and versions 1.1, 1.2, 1.4, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11.
 components:
   - kubectl

--- a/cves/CVE-2019-11247.yaml
+++ b/cves/CVE-2019-11247.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2019-11247
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-11247
 issueUrl: https://github.com/kubernetes/kubernetes/issues/80983
+published: 2019-08-05
 description: The Kubernetes kube-apiserver mistakenly allows access to a cluster-scoped custom resource if the request is made as if the resource were namespaced. Authorizations for the resource accessed in this manner are enforced using roles and role bindings within the namespace, meaning that a user with access only to a resource in one namespace could create, view update or delete the cluster-scoped resource (according to their namespace role privileges). Kubernetes affected versions include versions prior to 1.13.9, versions prior to 1.14.5, versions prior to 1.15.2, and versions 1.7, 1.8, 1.9, 1.10, 1.11, 1.12.
 components:
   - kube-apiserver

--- a/cves/CVE-2019-11248.yaml
+++ b/cves/CVE-2019-11248.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2019-11248
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-11248
 issueUrl: https://github.com/kubernetes/kubernetes/issues/81023
+published: 2019-08-06
 description: The debugging endpoint /debug/pprof is exposed over the unauthenticated Kubelet healthz port. The go pprof endpoint is exposed over the Kubelet's healthz port. This debugging endpoint can potentially leak sensitive information such as internal Kubelet memory addresses and configuration, or for limited denial of service. Versions prior to 1.15.0, 1.14.4, 1.13.8, and 1.12.10 are affected. The issue is of medium severity, but not exposed by the default configuration.
 components:
   - kubelet

--- a/cves/CVE-2019-11249.yaml
+++ b/cves/CVE-2019-11249.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2019-11249
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-11249
 issueUrl: https://github.com/kubernetes/kubernetes/issues/80984
+published: 2019-08-05
 description: The kubectl cp command allows copying files between containers and the user machine. To copy files from a container, Kubernetes runs tar inside the container to create a tar archive, copies it over the network, and kubectl unpacks it on the user’s machine. If the tar binary in the container is malicious, it could run any code and output unexpected, malicious results. An attacker could use this to write files to any path on the user’s machine when kubectl cp is called, limited only by the system permissions of the local user. Kubernetes affected versions include versions prior to 1.13.9, versions prior to 1.14.5, versions prior to 1.15.2, and versions 1.1, 1.2, 1.4, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 1.12.
 components:
   - kubectl

--- a/cves/CVE-2019-11250.yaml
+++ b/cves/CVE-2019-11250.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2019-11250
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-11250
 issueUrl: https://github.com/kubernetes/kubernetes/issues/81114
+published: 2019-08-07
 description: The Kubernetes client-go library logs request headers at verbosity levels of 7 or higher. This can disclose credentials to unauthorized users via logs or command output. Kubernetes components (such as kube-apiserver) prior to v1.16.0, which make use of basic or bearer token authentication, and run at high verbosity levels, are affected.
 components:
   - client-go

--- a/cves/CVE-2019-11251.yaml
+++ b/cves/CVE-2019-11251.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2019-11251
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-11251
 issueUrl: https://github.com/kubernetes/kubernetes/issues/87773
+published: 2020-02-03
 description: The Kubernetes kubectl cp command in versions 1.1-1.12, and versions prior to 1.13.11, 1.14.7, and 1.15.4 allows a combination of two symlinks provided by tar output of a malicious container to place a file outside of the destination directory specified in the kubectl cp invocation. This could be used to allow an attacker to place a nefarious file using a symlink, outside of the destination tree.
 components:
   - kubectl

--- a/cves/CVE-2019-11252.yaml
+++ b/cves/CVE-2019-11252.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2019-11252
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-11252
 issueUrl: https://github.com/kubernetes/kubernetes/pull/88684
+published: 2020-03-03
 description: The Kubernetes kube-controller-manager in versions v1.0-v1.17 is vulnerable to a credential leakage via error messages in mount failure logs and events for AzureFile and CephFS volumes.
 components:
   - kube-controller-manager

--- a/cves/CVE-2019-11253.yaml
+++ b/cves/CVE-2019-11253.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2019-11253
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-11253
 issueUrl: https://github.com/kubernetes/kubernetes/issues/83253
+published: 2019-09-27
 description: Improper input validation in the Kubernetes API server in versions v1.0-1.12 and versions prior to v1.13.12, v1.14.8, v1.15.5, and v1.16.2 allows authorized users to send malicious YAML or JSON payloads, causing the API server to consume excessive CPU or memory, potentially crashing and becoming unavailable. Prior to v1.14.0, default RBAC policy authorized anonymous users to submit requests that could trigger this vulnerability. Clusters upgraded from a version prior to v1.14.0 keep the more permissive policy by default for backwards compatibility.
 components:
   - kube-apiserver

--- a/cves/CVE-2019-11254.yaml
+++ b/cves/CVE-2019-11254.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2019-11254
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-11254
 issueUrl: https://github.com/kubernetes/kubernetes/issues/89535
+published: 2020-03-26
 description: The Kubernetes API Server component in versions 1.1-1.14, and versions prior to 1.15.10, 1.16.8 and 1.17.3 allows an authorized user who sends malicious YAML payloads to cause the kube-apiserver to consume excessive CPU cycles while parsing YAML.
 components:
   - kube-apiserver

--- a/cves/CVE-2019-16276.yaml
+++ b/cves/CVE-2019-16276.yaml
@@ -1,5 +1,6 @@
 cve: CVE-2019-16276
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-16276
+published: 2019-09-30
 description: Go before 1.12.10 and 1.13.x before 1.13.1 allow HTTP Request Smuggling.
 components:
   - client-go

--- a/cves/CVE-2019-9512.yaml
+++ b/cves/CVE-2019-9512.yaml
@@ -1,5 +1,6 @@
 cve: CVE-2019-9512
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-9512
+published: 2019-08-13
 description: Some HTTP/2 implementations are vulnerable to ping floods, potentially leading to a denial of service. The attacker sends continual pings to an HTTP/2 peer, causing the peer to build an internal queue of responses. Depending on how efficiently this data is queued, this can consume excess CPU, memory, or both.
 components:
   - client-go

--- a/cves/CVE-2019-9514.yaml
+++ b/cves/CVE-2019-9514.yaml
@@ -1,5 +1,6 @@
 cve: CVE-2019-9514
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-9514
+published: 2019-08-13
 description: Some HTTP/2 implementations are vulnerable to a reset flood, potentially leading to a denial of service. The attacker opens a number of streams and sends an invalid request over each stream that should solicit a stream of RST_STREAM frames from the peer. Depending on how the peer queues the RST_STREAM frames, this can consume excess memory, CPU, or both.
 components:
   - client-go

--- a/cves/CVE-2019-9946.yaml
+++ b/cves/CVE-2019-9946.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2019-9946
 url: https://nvd.nist.gov/vuln/detail/CVE-2019-9946
 issueUrl: https://github.com/kubernetes/kubernetes/pull/75455
+published: 2019-03-18
 description: Cloud Native Computing Foundation (CNCF) CNI (Container Networking Interface) 0.7.4 has a network firewall misconfiguration which affects Kubernetes. The CNI 'portmap' plugin, used to setup HostPorts for CNI, inserts rules at the front of the iptables nat chains; which take precedence over the KUBE- SERVICES chain. Because of this, the HostPort/portmap rule could match incoming traffic even if there were better fitting, more specific service definition rules like NodePorts later in the chain. The issue is fixed in CNI 0.7.5 and Kubernetes 1.11.9, 1.12.7, 1.13.5, and 1.14.0.
 cvss:
   nvd:

--- a/cves/CVE-2020-10749.yaml
+++ b/cves/CVE-2020-10749.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2020-10749
 url: https://nvd.nist.gov/vuln/detail/CVE-2020-10749
 issueUrl: https://github.com/kubernetes/kubernetes/issues/91507
+published: 2020-05-27
 description: A vulnerability was found in all versions of containernetworking/plugins before version 0.8.6, that allows malicious containers in Kubernetes clusters to perform man-in-the-middle (MitM) attacks. A malicious container can exploit this flaw by sending rogue IPv6 router advertisements to the host or other containers, to redirect traffic to the malicious container.
 components:
   - kubelet

--- a/cves/CVE-2020-8551.yaml
+++ b/cves/CVE-2020-8551.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2020-8551
 url: https://nvd.nist.gov/vuln/detail/CVE-2020-8551
 issueUrl: https://github.com/kubernetes/kubernetes/issues/89377
+published: 2020-03-23
 description: The Kubelet component in versions 1.15.0-1.15.9, 1.16.0-1.16.6, and 1.17.0-1.17.2 has been found to be vulnerable to a denial of service attack via the kubelet API, including the unauthenticated HTTP read-only API typically served on port 10255, and the authenticated HTTPS API typically served on port 10250.
 components:
   - kubelet

--- a/cves/CVE-2020-8552.yaml
+++ b/cves/CVE-2020-8552.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2020-8552
 url: https://nvd.nist.gov/vuln/detail/CVE-2020-8552
 issueUrl: https://github.com/kubernetes/kubernetes/issues/89378
+published: 2020-03-23
 description: The Kubernetes API server component in versions prior to 1.15.9, 1.16.0-1.16.6, and 1.17.0-1.17.2 has been found to be vulnerable to a denial of service attack via successful API requests.
 components:
   - kube-apiserver

--- a/cves/CVE-2020-8554.yaml
+++ b/cves/CVE-2020-8554.yaml
@@ -1,5 +1,6 @@
 cve: CVE-2020-8554
 issueUrl: https://github.com/kubernetes/kubernetes/issues/97076
+published: 2020-12-04
 description: |
   This issue affects multitenant clusters. If a potential attacker can already create or edit services and pods, then they may be able to intercept traffic from other pods (or nodes) in the cluster.
   An attacker that is able to create a ClusterIP service and set the spec.externalIPs field can intercept traffic to that IP. An attacker that is able to patch the status (which is considered a privileged operation and should not typically be granted to users) of a LoadBalancer service can set the status.loadBalancer.ingress.ip to similar effect.

--- a/cves/CVE-2020-8555.yaml
+++ b/cves/CVE-2020-8555.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2020-8555
 url: https://nvd.nist.gov/vuln/detail/CVE-2020-8555
 issueUrl: https://github.com/kubernetes/kubernetes/issues/91542
+published: 2020-05-28
 description: The Kubernetes kube-controller-manager in versions v1.0-1.14, versions prior to v1.15.12, v1.16.9, v1.17.5, and version v1.18.0 are vulnerable to a Server Side Request Forgery (SSRF) that allows certain authorized users to leak up to 500 bytes of arbitrary information from unprotected endpoints within the master's host network (such as link-local or loopback services).
 components:
   - kube-controller-manager

--- a/cves/CVE-2020-8557.yaml
+++ b/cves/CVE-2020-8557.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2020-8557
 url: https://nvd.nist.gov/vuln/detail/CVE-2020-8557
 issueUrl: https://github.com/kubernetes/kubernetes/issues/93032
+published: 2020-07-13
 description: The Kubernetes kubelet component in versions 1.1-1.16.12, 1.17.0-1.17.8 and 1.18.0-1.18.5 do not account for disk usage by a pod which writes to its own /etc/hosts file. The /etc/hosts file mounted in a pod by kubelet is not included by the kubelet eviction manager when calculating ephemeral storage usage by a pod. If a pod writes a large amount of data to the /etc/hosts file, it could fill the storage space of the node and cause the node to fail.
 components:
   - kubelet

--- a/cves/CVE-2020-8558.yaml
+++ b/cves/CVE-2020-8558.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2020-8558
 url: https://nvd.nist.gov/vuln/detail/CVE-2020-8558
 issueUrl: https://github.com/kubernetes/kubernetes/issues/92315
+published: 2020-06-19
 description: The Kubelet and kube-proxy components in versions 1.1.0-1.16.10, 1.17.0-1.17.6, and 1.18.0-1.18.3 were found to contain a security issue which allows adjacent hosts to reach TCP and UDP services bound to 127.0.0.1 running on the node or in the node's network namespace. Such a service is generally thought to be reachable only by other processes on the same host, but due to this defeect, could be reachable by other hosts on the same LAN as the node, or by containers running on the same node as the service.
 components:
   - kube-proxy

--- a/cves/CVE-2020-8559.yaml
+++ b/cves/CVE-2020-8559.yaml
@@ -1,6 +1,7 @@
 cve: CVE-2020-8559
 url: https://nvd.nist.gov/vuln/detail/CVE-2020-8559
 issueUrl: https://github.com/kubernetes/kubernetes/issues/92914
+published: 2020-07-08
 description: The Kubernetes kube-apiserver in versions v1.6-v1.15, and versions prior to v1.16.13, v1.17.9 and v1.18.6 are vulnerable to an unvalidated redirect on proxied upgrade requests that could allow an attacker to escalate privileges from a node compromise to a full cluster compromise.
 components:
   - kube-apiserver

--- a/cves/CVE-2020-8561.yaml
+++ b/cves/CVE-2020-8561.yaml
@@ -1,5 +1,6 @@
 cve: CVE-2020-8561
 issueUrl: https://github.com/kubernetes/kubernetes/issues/104720
+published: 2021-09-01
 description: A security issue was discovered in Kubernetes where actors that control the responses of MutatingWebhookConfiguration or ValidatingWebhookConfiguration requests are able to redirect kube-apiserver requests to private networks of the apiserver. If that user can view kube-apiserver logs when the log level is set to 10, they can view the redirected responses and headers in the logs.
 components:
   - kube-apiserver

--- a/cves/CVE-2020-8562.yaml
+++ b/cves/CVE-2020-8562.yaml
@@ -1,5 +1,6 @@
 cve: CVE-2020-8562
 issueUrl: https://github.com/kubernetes/kubernetes/issues/101493
+published: 2021-04-26
 description: A security issue was discovered in Kubernetes where an authorized user may be able to access private networks on the Kubernetes control plane components. Kubernetes clusters are only affected if an untrusted user can create or modify Node objects and proxy to them, or an untrusted user can create or modify StorageClass objects and access KubeControllerManager logs.
 cvss:
   kubernetes:

--- a/cves/CVE-2020-8563.yaml
+++ b/cves/CVE-2020-8563.yaml
@@ -1,5 +1,6 @@
 cve: CVE-2020-8563
 issueUrl: https://github.com/kubernetes/kubernetes/issues/95621
+published: 2020-10-15
 description: In Kubernetes clusters using VSphere as a cloud provider, with a logging level set to 4 or above, VSphere cloud credentials will be leaked in the cloud controller manager's log.
 components:
   - kube-controller-manager

--- a/cves/CVE-2020-8564.yaml
+++ b/cves/CVE-2020-8564.yaml
@@ -1,5 +1,6 @@
 cve: CVE-2020-8564
 issueUrl: https://github.com/kubernetes/kubernetes/issues/95622
+published: 2020-10-15
 description: In Kubernetes clusters using a logging level of at least 4, processing a malformed docker config file will result in the contents of the docker config file being leaked, which can include pull secrets or other registry credentials.
 cvss:
   kubernetes:

--- a/cves/CVE-2020-8565.yaml
+++ b/cves/CVE-2020-8565.yaml
@@ -1,5 +1,6 @@
 cve: CVE-2020-8565
 issueUrl: https://github.com/kubernetes/kubernetes/issues/95623
+published: 2020-10-15
 description: In Kubernetes, if the logging level is to at least 9, authorization and bearer tokens will be written to log files. This can occur both in API server logs and client tool output like kubectl.
 components:
   - client-go

--- a/cves/CVE-2020-8566.yaml
+++ b/cves/CVE-2020-8566.yaml
@@ -1,5 +1,6 @@
 cve: CVE-2020-8566
 issueUrl: https://github.com/kubernetes/kubernetes/issues/95624
+published: 2020-10-15
 description: In Kubernetes clusters using Ceph RBD as a storage provisioner, with logging level of at least 4, Ceph RBD admin secrets can be written to logs. This occurs in kube-controller-manager's logs during provisioning of Ceph RBD persistent claims.
 cvss:
   kubernetes:

--- a/cves/CVE-2021-25735.yaml
+++ b/cves/CVE-2021-25735.yaml
@@ -1,5 +1,6 @@
 cve: CVE-2021-25735
 issueUrl: https://github.com/kubernetes/kubernetes/issues/100096
+published: 2021-03-10
 description: A security issue was discovered in kube-apiserver that could allow node updates to bypass a Validating Admission Webhook. You are only affected by this vulnerability if you run a Validating Admission Webhook for Nodes that denies admission based at least partially on the old state of the Node object.
 components:
   - kube-apiserver

--- a/cves/CVE-2021-25737.yaml
+++ b/cves/CVE-2021-25737.yaml
@@ -1,5 +1,6 @@
 cve: CVE-2021-25737
 issueUrl: https://github.com/kubernetes/kubernetes/issues/102106
+published: 2021-05-18
 description: A security issue was discovered in Kubernetes where a user may be able to redirect pod traffic to private networks on a Node. Kubernetes already prevents creation of Endpoint IPs in the localhost or link-local range, but the same validation was not performed on EndpointSlice IPs.
 components:
   - kube-apiserver

--- a/cves/CVE-2021-25740.yaml
+++ b/cves/CVE-2021-25740.yaml
@@ -1,5 +1,6 @@
 cve: CVE-2021-25740
 issueUrl: https://github.com/kubernetes/kubernetes/issues/103675
+published: 2021-07-13
 description: A security issue was discovered with Kubernetes that could enable users to send network traffic to locations they would otherwise not have access to via a confused deputy attack.
 cvss:
   kubernetes:

--- a/cves/CVE-2021-25741.yaml
+++ b/cves/CVE-2021-25741.yaml
@@ -1,5 +1,6 @@
 cve: CVE-2021-25741
 issueUrl: https://github.com/kubernetes/kubernetes/issues/104980
+published: 2021-09-13
 description: A security issue was discovered in Kubernetes where a user may be able to create a container with subpath volume mounts to access files & directories outside of the volume, including on the host filesystem.
 components:
   - kubelet

--- a/pkg/validation/types.go
+++ b/pkg/validation/types.go
@@ -1,10 +1,15 @@
 package validation
 
+import "time"
+
+const TimeFormat = "2006-01-02"
+
 // CVESchema is the schema for the entire CVE file.
 type CVESchema struct {
 	CVE         string           `json:"cve"`
 	URL         string           `json:"url"`
 	IssueURL    string           `json:"issueUrl"`
+	Published   Time             `json:"published"`
 	Description string           `json:"description"`
 	Components  []string         `json:"components"`
 	CVSS        *CVSSSchema      `json:"cvss"`
@@ -35,4 +40,23 @@ type KubernetesSchema struct {
 type AffectedSchema struct {
 	Range   string `json:"range"`
 	FixedBy string `json:"fixedBy"`
+}
+
+// Time is a wrapper around time.Time.
+// The default UnmarshalJSON for time.Time expects the time.RFC3339 format,
+// which is not what is used in this repo.
+type Time struct {
+	time.Time
+}
+
+// UnmarshalJSON is inspired by the Go 1.18 (*time.Time).UnmarshalJSON implementation
+// https://cs.opensource.google/go/go/+/refs/tags/go1.18:src/time/time.go;l=1298.
+func (t *Time) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+
+	var err error
+	t.Time, err = time.Parse(`"`+TimeFormat+`"`, string(data))
+	return err
 }

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -1,13 +1,14 @@
 package validation
 
 import (
+	"regexp"
+	"strings"
+	"time"
+
 	"github.com/facebookincubator/nvdtools/cvss2"
 	"github.com/facebookincubator/nvdtools/cvss3"
 	"github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
-	"regexp"
-	"strings"
-	"time"
 )
 
 func init() {


### PR DESCRIPTION
This will trigger an update from all live StackRox Scanners. However, these files are very small, and performing the updates for Kubernetes CVEs is very cheap, so this is ok