### PR TITLE
CVE-2021-25749, CVE-2023-3676, CVE-2023-3955, CVE-2024-3177

### DIFF
--- a/cves/CVE-2021-25749.yaml
+++ b/cves/CVE-2021-25749.yaml
@@ -1,0 +1,19 @@
+cve: CVE-2021-25749
+issueUrl: https://github.com/kubernetes/kubernetes/issues/112192
+published: 2022-09-15T00:00Z
+description: A security issue was discovered in Kubernetes that could allow Windows workloads to run as ContainerAdministrator even when those workloads set the runAsNonRoot option to true.
+components:
+  - kubelet
+cvss:
+  kubernetes:
+    scoreV3: 7.8
+    vectorV3: CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+affected:
+  - range: ">= 1.20, <= 1.22.13"
+    fixedBy: "1.22.14"
+  - range: ">= 1.23.0, <= 1.23.10"
+    fixedBy: "1.23.11"
+  - range: ">= 1.24.0, <= 1.24.4"
+    fixedBy: "1.24.5"
+  - range: ">= 1.25, < 1.25.0"
+    fixedBy: "1.25.0"

--- a/cves/CVE-2023-3676.yaml
+++ b/cves/CVE-2023-3676.yaml
@@ -1,0 +1,21 @@
+cve: CVE-2023-3676
+issueUrl: https://github.com/kubernetes/kubernetes/issues/119339
+published: 2023-07-14T00:00Z
+description: A security issue was discovered in Kubernetes where a user that can create pods on Windows nodes may be able to escalate to admin privileges on those nodes. Kubernetes clusters are only affected if they include Windows nodes.
+components:
+  - kubelet
+cvss:
+  kubernetes:
+    scoreV3: 8.8
+    vectorV3: CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+affected:
+  - range: "<= 1.24.16"
+    fixedBy: "1.24.17"
+  - range: ">= 1.25, <= 1.25.12"
+    fixedBy: "1.25.13"
+  - range: ">= 1.26, <= 1.26.7"
+    fixedBy: "1.26.8"
+  - range: ">= 1.27, <= 1.27.4"
+    fixedBy: "1.27.5"
+  - range: ">= 1.28, < 1.28.1"
+    fixedBy: "1.28.1"

--- a/cves/CVE-2023-3955.yaml
+++ b/cves/CVE-2023-3955.yaml
@@ -1,0 +1,21 @@
+cve: CVE-2023-3955
+issueUrl: https://github.com/kubernetes/kubernetes/issues/119595
+published: 2023-07-14T00:00Z
+description: A security issue was discovered in Kubernetes where a user that can create pods on Windows nodes may be able to escalate to admin privileges on those nodes. Kubernetes clusters are only affected if they include Windows nodes.
+components:
+  - kubelet
+cvss:
+  kubernetes:
+    scoreV3: 8.8
+    vectorV3: CVSS:3.1/av:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+affected:
+  - range: "<= 1.24.16"
+    fixedBy: "1.24.17"
+  - range: ">= 1.25, <= 1.25.12"
+    fixedBy: "1.25.13"
+  - range: ">= 1.26, <= 1.26.7"
+    fixedBy: "1.26.8"
+  - range: ">= 1.27, <= 1.27.4"
+    fixedBy: "1.27.5"
+  - range: ">= 1.28, < 1.28.1"
+    fixedBy: "1.28.1"

--- a/cves/CVE-2024-3177.yaml
+++ b/cves/CVE-2024-3177.yaml
@@ -1,0 +1,18 @@
+cve: CVE-2024-3177
+issueUrl: https://github.com/kubernetes/kubernetes/issues/124336
+published: 2024-04-16T00:00Z
+description: |
+  A security issue was discovered in Kubernetes where users may be able to launch containers that bypass the mountable secrets policy enforced by the ServiceAccount admission plugin when using containers, init containers, and ephemeral containers with the envFrom field populated. The policy ensures pods running with a service account may only reference secrets specified in the service account’s secrets field. Kubernetes clusters are only affected if the ServiceAccount admission plugin and the kubernetes.io/enforce-mountable-secrets annotation are used together with containers, init containers, and ephemeral containers with the envFrom field populated.
+components:
+  - kube-apiserver
+cvss:
+  kubernetes:
+    scoreV3: 2.7
+    vectorV3: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:N
+affected:
+  - range: "<= 1.27.12"
+    fixedBy: "1.27.13"
+  - range: ">= 1.28, <= 1.28.8"
+    fixedBy: "1.28.9"
+  - range: ">= 1.29, <= 1.29.3"
+    fixedBy: "1.29.4"


### PR DESCRIPTION
New CVE from today + older CVEs which were Window-only. Decided to add them. Previously, we ignore them because we don't support Windows nodes, but I figure perhaps it's up to the end-user to determine if it's relevant or not, and not the job of the data source